### PR TITLE
fix(rio): enable deletion of old deploy files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ deploy {
                 frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
-                    deleteOldFiles = false // Change to true to delete files on roboRIO that no
+                    deleteOldFiles = true  // Change to true to delete files on roboRIO that no
                                            // longer exist in deploy directory of this project
                 }
             }


### PR DESCRIPTION
There's an issue with things like PathPlanner where if you don't clean the deploy firectory on the RIO, it can lead to some orphaned files that can mess up the code. I believe this also has the added benefit of forcing the update of edited files, which was a problem that you had to SSH into the RIO to fix. It was annoying. I don't want to have that happen this year.