### PR TITLE
chore(vendordeps): update vendor dependencies

### DIFF
--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,7 +1,7 @@
 {
   "fileName": "AdvantageKit.json",
   "name": "AdvantageKit",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
   "frcYear": "2025",
   "mavenUrls": [
@@ -12,14 +12,14 @@
     {
       "groupId": "org.littletonrobotics.akit",
       "artifactId": "akit-java",
-      "version": "4.1.0"
+      "version": "4.1.1"
     }
   ],
   "jniDependencies": [
     {
       "groupId": "org.littletonrobotics.akit",
       "artifactId": "akit-wpilibio",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "skipInvalidPlatforms": false,
       "isJar": false,
       "validPlatforms": [

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "PathplannerLib.json",
   "name": "PathplannerLib",
-  "version": "2025.2.2",
+  "version": "2025.2.5",
   "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
   "frcYear": "2025",
   "mavenUrls": [
@@ -12,7 +12,7 @@
     {
       "groupId": "com.pathplanner.lib",
       "artifactId": "PathplannerLib-java",
-      "version": "2025.2.2"
+      "version": "2025.2.5"
     }
   ],
   "jniDependencies": [],
@@ -20,7 +20,7 @@
     {
       "groupId": "com.pathplanner.lib",
       "artifactId": "PathplannerLib-cpp",
-      "version": "2025.2.2",
+      "version": "2025.2.5",
       "libName": "PathplannerLib",
       "headerClassifier": "headers",
       "sharedLibrary": false,

--- a/vendordeps/Phoenix6-frc2025-latest.json
+++ b/vendordeps/Phoenix6-frc2025-latest.json
@@ -1,7 +1,7 @@
 {
   "fileName": "Phoenix6-frc2025-latest.json",
   "name": "CTRE-Phoenix (v6)",
-  "version": "25.2.1",
+  "version": "25.3.1",
   "frcYear": "2025",
   "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
   "mavenUrls": [
@@ -19,14 +19,14 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-java",
-      "version": "25.2.1"
+      "version": "25.3.1"
     }
   ],
   "jniDependencies": [
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "api-cpp",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -40,7 +40,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -54,7 +54,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "api-cpp-sim",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -68,7 +68,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -82,7 +82,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -96,7 +96,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -110,7 +110,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -124,7 +124,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -138,7 +138,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -152,7 +152,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFXS",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -166,7 +166,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -180,7 +180,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -194,7 +194,21 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANrange",
-      "version": "25.2.1",
+      "version": "25.3.1",
+      "isJar": false,
+      "skipInvalidPlatforms": true,
+      "validPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANdi",
+      "version": "25.3.1",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -210,7 +224,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-cpp",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_Phoenix6_WPI",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -226,7 +240,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_PhoenixTools",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -242,7 +256,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "wpiapi-cpp-sim",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_Phoenix6_WPISim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -258,7 +272,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_PhoenixTools_Sim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -274,7 +288,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimTalonSRX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -290,7 +304,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimVictorSPX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -306,7 +320,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimPigeonIMU",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -322,7 +336,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimCANCoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -338,7 +352,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimProTalonFX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -354,7 +368,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFXS",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimProTalonFXS",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -370,7 +384,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimProCANcoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -386,7 +400,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimProPigeon2",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -402,8 +416,24 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANrange",
-      "version": "25.2.1",
+      "version": "25.3.1",
       "libName": "CTRE_SimProCANrange",
+      "headerClassifier": "headers",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANdi",
+      "version": "25.3.1",
+      "libName": "CTRE_SimProCANdi",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,

--- a/vendordeps/maple-sim.json
+++ b/vendordeps/maple-sim.json
@@ -1,7 +1,7 @@
 {
   "fileName": "maple-sim.json",
   "name": "maplesim",
-  "version": "0.3.5",
+  "version": "0.3.10",
   "frcYear": "2025",
   "uuid": "c39481e8-4a63-4a4c-9df6-48d91e4da37b",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "org.ironmaple",
       "artifactId": "maplesim-java",
-      "version": "0.3.5"
+      "version": "0.3.10"
     },
     {
       "groupId": "org.dyn4j",

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2025.1.1",
+  "version": "v2025.2.1",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "frcYear": "2025",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2025.1.1",
+      "version": "v2025.2.1",
       "skipInvalidPlatforms": true,
       "isJar": false,
       "validPlatforms": [
@@ -28,7 +28,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-cpp",
-      "version": "v2025.1.1",
+      "version": "v2025.2.1",
       "libName": "photonlib",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -43,7 +43,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2025.1.1",
+      "version": "v2025.2.1",
       "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -60,12 +60,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-java",
-      "version": "v2025.1.1"
+      "version": "v2025.2.1"
     },
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-java",
-      "version": "v2025.1.1"
+      "version": "v2025.2.1"
     }
   ]
 }


### PR DESCRIPTION
This pull request includes version updates for various dependencies in multiple JSON files. These updates are primarily focused on keeping the dependencies up-to-date with their latest versions.

Dependency version updates:

* [`vendordeps/AdvantageKit.json`](diffhunk://#diff-5a8e5335ea92ea10da55f3eb374d3b77049740196db1ef2a71f3abac390166caL4-R4): Updated version from `4.1.0` to `4.1.1` for `AdvantageKit` dependencies. [[1]](diffhunk://#diff-5a8e5335ea92ea10da55f3eb374d3b77049740196db1ef2a71f3abac390166caL4-R4) [[2]](diffhunk://#diff-5a8e5335ea92ea10da55f3eb374d3b77049740196db1ef2a71f3abac390166caL15-R22)
* [`vendordeps/PathplannerLib.json`](diffhunk://#diff-58e961cc5ea60fe19dfac962e8b15918bc236b9d0536123e2d7a7a7845cb3b39L4-R4): Updated version from `2025.2.2` to `2025.2.5` for `PathplannerLib` dependencies. [[1]](diffhunk://#diff-58e961cc5ea60fe19dfac962e8b15918bc236b9d0536123e2d7a7a7845cb3b39L4-R4) [[2]](diffhunk://#diff-58e961cc5ea60fe19dfac962e8b15918bc236b9d0536123e2d7a7a7845cb3b39L15-R23)
* [`vendordeps/Phoenix6-frc2025-latest.json`](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L4-R4): Updated version from `25.2.1` to `25.3.1` for multiple `CTRE-Phoenix` dependencies and added new dependencies for simulation. [[1]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L4-R4) [[2]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L22-R29) [[3]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L43-R43) [[4]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L57-R57) [[5]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L71-R71) [[6]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L85-R85) [[7]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L99-R99) [[8]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L113-R113) [[9]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L127-R127) [[10]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L141-R141) [[11]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L155-R155) [[12]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L169-R169) [[13]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L183-R183) [[14]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L197-R211) [[15]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L213-R227) [[16]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L229-R243) [[17]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L245-R259) [[18]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L261-R275) [[19]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L277-R291) [[20]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L293-R307) [[21]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L309-R323) [[22]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L325-R339) [[23]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L341-R355) [[24]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L357-R371) [[25]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L373-R387) [[26]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L389-R403) [[27]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7L405-R419) [[28]](diffhunk://#diff-2845c5a11ee6931905100ee82b1611644ab683fabb5275f1daa72a705f73a5c7R431-R446)
* [`vendordeps/maple-sim.json`](diffhunk://#diff-5918d1b932a4b916e78f8aa4cc1cea13b2b41b86b71f63a56764242f1475d2beL4-R4): Updated version from `0.3.5` to `0.3.10` for `maplesim` dependencies. [[1]](diffhunk://#diff-5918d1b932a4b916e78f8aa4cc1cea13b2b41b86b71f63a56764242f1475d2beL4-R4) [[2]](diffhunk://#diff-5918d1b932a4b916e78f8aa4cc1cea13b2b41b86b71f63a56764242f1475d2beL16-R16)
* [`vendordeps/photonlib.json`](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L4-R4): Updated version from `v2025.1.1` to `v2025.2.1` for `photonlib` dependencies. [[1]](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L4-R4) [[2]](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L16-R16) [[3]](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L31-R31) [[4]](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L46-R46) [[5]](diffhunk://#diff-62d58aaebc81902c9fea969db5dd9bcdefd1a0df2a3d2230ba830bc3e60a1286L63-R68)